### PR TITLE
Type fix for 64-bit compilation

### DIFF
--- a/main.c
+++ b/main.c
@@ -37,7 +37,7 @@ libusb_device_handle * LIBUSB_CALL open_device_with_vid(
 	struct libusb_device *found = NULL;
 	struct libusb_device *dev;
 	struct libusb_device_handle *handle = NULL;
-	size_t i = 0;
+	uint32_t i = 0;
 	int r;
 
 	if (libusb_get_device_list(ctx, &devs) < 0)


### PR DESCRIPTION
Without this fix, I get an error saying
```
main.c: In function ‘open_device_with_vid’:
main.c:52:4: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ [-Wformat=]
    printf("Found device %d idVendor=0x%04x idProduct=0x%04x\n", i, desc.idVendor, desc.idProduct);
    ^
```
when compiling on a x64 Ubuntu 14.04 host.

Given that it's only iterating the results from `libusb_get_device_list`, I suspect that an `int` is still _more_ than sufficient ;-)