### PR TITLE
Execute both sending bootcode.bin and second stage boot server when

### DIFF
--- a/main.c
+++ b/main.c
@@ -393,6 +393,7 @@ int file_server(libusb_device_handle * usb_device)
 		}
 	}
 
+	printf("Second stage boot server done\n");
 	return 0;
 }
 
@@ -492,7 +493,7 @@ int main(int argc, char *argv[])
 		libusb_close(usb_device);
 		sleep(5);
 	}
-	while(loop);
+	while(loop || desc.iSerialNumber == 0);
 
 	libusb_exit(ctx);
 


### PR DESCRIPTION
loop=0

This should fix the logic when loop=0. It will then both execute the sending of bootcode.bin and the second stage boot server (sending start.elf).
Tested on PiZero and Slice1. Slice1 is put in MSD mode with access to eMMC.
Here the dmesg output from Slice1:
```
[ 8318.498490] usb 1-1.4: USB disconnect, device number 65
[ 8324.113440] usb 1-1.4: new full-speed USB device number 66 using dwc_otg
[ 8324.223731] usb 1-1.4: New USB device found, idVendor=0a5c, idProduct=2763
[ 8324.223747] usb 1-1.4: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[ 8324.223755] usb 1-1.4: Product: BCM2708 Boot
[ 8324.223763] usb 1-1.4: Manufacturer: Broadcom
[ 8325.667562] usb 1-1.4: USB disconnect, device number 66
[ 8326.923469] usb 1-1.4: new high-speed USB device number 67 using dwc_otg
[ 8327.024425] usb 1-1.4: New USB device found, idVendor=0a5c, idProduct=2764
[ 8327.024454] usb 1-1.4: New USB device strings: Mfr=1, Product=2, SerialNumber=1
[ 8327.024462] usb 1-1.4: Product: BCM2710 Boot
[ 8327.024470] usb 1-1.4: Manufacturer: Broadcom
[ 8327.024478] usb 1-1.4: SerialNumber: Broadcom
[ 8330.788183] usb 1-1.4: USB disconnect, device number 67
[ 8331.063498] usb 1-1.4: new high-speed USB device number 68 using dwc_otg
[ 8331.163987] usb 1-1.4: New USB device found, idVendor=0a5c, idProduct=0001
[ 8331.164004] usb 1-1.4: New USB device strings: Mfr=2, Product=1, SerialNumber=3
[ 8331.164012] usb 1-1.4: Product: Compute Module
[ 8331.164019] usb 1-1.4: Manufacturer: Raspberry Pi
[ 8331.164027] usb 1-1.4: SerialNumber: 0001
[ 8331.164940] usb-storage 1-1.4:1.0: USB Mass Storage device detected
[ 8331.165500] scsi host26: usb-storage 1-1.4:1.0
[ 8332.164152] scsi 26:0:0:0: Direct-Access     RPi-MSD- 0001                  PQ: 0 ANSI: 2
[ 8332.165102] sd 26:0:0:0: Attached scsi generic sg0 type 0
[ 8332.165184] sd 26:0:0:0: [sda] 7634944 512-byte logical blocks: (3.91 GB/3.64 GiB)
[ 8332.165568] sd 26:0:0:0: [sda] Write Protect is off
[ 8332.165584] sd 26:0:0:0: [sda] Mode Sense: 0f 00 00 00
[ 8332.165826] sd 26:0:0:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
[ 8332.180742]  sda: sda1 sda2 < sda5 > sda3
[ 8332.182734] sd 26:0:0:0: [sda] Attached SCSI removable disk
[ 8332.872400] FAT-fs (sda5): Volume was not properly unmounted. Some data may be corrupt. Please run fsck.
[ 8332.900501] EXT4-fs (sda3): recovery complete
[ 8332.900574] EXT4-fs (sda3): mounted filesystem with ordered data mode. Opts: (null)
```