### PR TITLE
Flush stdout buffer immediately

### DIFF
--- a/main.c
+++ b/main.c
@@ -409,6 +409,9 @@ int main(int argc, char *argv[])
 
 	get_options(argc, argv);
 
+	// flush immediately
+	setbuf(stdout, NULL);
+
 #if defined (__CYGWIN__)
 	//printf("Running under Cygwin\n");
 #else


### PR DESCRIPTION
Enable immediately stdout flushing for better integration with automated sdout parsing from external application.