### PR TITLE
Transfer files in chunks using libusb async I/O.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 rpiboot: main.c
-	$(CC) -Wall -Wextra -g -o $@ $< -lusb-1.0
+	$(CC) -std=c99 -Wall -Wextra -g -o $@ $< -lusb-1.0
 
 uninstall:
 	rm -f /usr/bin/rpiboot


### PR DESCRIPTION
Using multiple transfers allows to serve big files and also generally improves performance.
Fixes #14