### PR TITLE
Improve portability (BSD)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CFLAGS	= -Wall -Wextra -g `pkg-config --cflags libusb-1.0`
 LDFLAGS	= `pkg-config --libs libusb-1.0`
 
 rpiboot: main.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ main.c
 
 uninstall:
 	rm -f /usr/bin/rpiboot

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+CFLAGS	= -Wall -Wextra -g `pkg-config --cflags libusb-1.0`
+LDFLAGS	= `pkg-config --libs libusb-1.0`
+
 rpiboot: main.c
-	$(CC) -Wall -Wextra -g -o $@ $< -lusb-1.0
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
 
 uninstall:
 	rm -f /usr/bin/rpiboot

--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
The two commits suggested here help build the project on platforms with libusb outside of the base system (like BSD ports) and a non-GNU make.