### PR TITLE
Fix error reporting.

### DIFF
--- a/main.c
+++ b/main.c
@@ -388,6 +388,11 @@ int second_stage_boot(libusb_device_handle *usb_device)
 
 	sleep(1);
 	size = ep_read((unsigned char *)&retcode, sizeof(retcode), usb_device);
+	if (size == -4)
+	{
+		printf("Disconnected !\n");
+		return 0;
+	}
 
 	if (size > 0 && retcode == 0)
 	{
@@ -395,7 +400,7 @@ int second_stage_boot(libusb_device_handle *usb_device)
 	}
 	else
 	{
-		printf("Failed : 0x%x\n", retcode);
+		printf("Failed : %d,0x%x\n", size, retcode);
 	}
 
 	return retcode;


### PR DESCRIPTION
Failure may come from the device or the host, so report both return codes.

"Failed : -4,0x0" indicates  "LIBUSB_ERROR_NO_DEVICE", which I am seeing 25% of the time regardless of the length of delay before requesting status, but does not mean that uploading bootcode.bin has failed. 