### PR TITLE
Change timeout in ep_read to 3 seconds

### DIFF
--- a/main.c
+++ b/main.c
@@ -238,7 +238,7 @@ int ep_read(void *buf, int len, libusb_device_handle * usb_device)
 	    libusb_control_transfer(usb_device,
 				    LIBUSB_REQUEST_TYPE_VENDOR |
 				    LIBUSB_ENDPOINT_IN, 0, len & 0xffff,
-				    len >> 16, buf, len, 2000);
+				    len >> 16, buf, len, 3000);
 	if(ret >= 0)
 		return len;
 	else


### PR DESCRIPTION
With recent kernels I get timeouts booting Linux with rpiboot, after increasing the timeout to 3000 I have no issues.

Debugging I see the ep_read call after ReadFile: cmdline.txt (before it tries to retrieve recovery.img/kernel.img) takes around 2.1-2.2 seconds which looks to be related to the size of the iniramfs I'm using.