### PR TITLE
Avoid warning 'libusb_set_debug deprecated'

### DIFF
--- a/main.c
+++ b/main.c
@@ -617,7 +617,11 @@ int main(int argc, char *argv[])
 		exit(-1);
 	}
 
+#if LIBUSBX_API_VERSION < 0x01000106
 	libusb_set_debug(ctx, verbose ? LIBUSB_LOG_LEVEL_WARNING : 0);
+#else
+	libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, 0);
+#endif
 
 	do
 	{

--- a/main.c
+++ b/main.c
@@ -620,7 +620,11 @@ int main(int argc, char *argv[])
 #if LIBUSBX_API_VERSION < 0x01000106
 	libusb_set_debug(ctx, verbose ? LIBUSB_LOG_LEVEL_WARNING : 0);
 #else
-	libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, 0);
+	libusb_set_option(
+		ctx,
+		LIBUSB_OPTION_LOG_LEVEL,
+		verbose ? verbose == 2 ? LIBUSB_LOG_LEVEL_INFO : LIBUSB_LOG_LEVEL_WARNING : 0
+		);
 #endif
 
 	do


### PR DESCRIPTION
See: #53