### PR TITLE
2711: Fix handling of serial numbers in single shot mode

### DIFF
--- a/main.c
+++ b/main.c
@@ -676,7 +676,7 @@ int main(int argc, char *argv[])
 		libusb_close(usb_device);
 		sleep(1);
 	}
-	while(loop || desc.iSerialNumber == 0);
+	while(loop || desc.iSerialNumber == 0 || desc.iSerialNumber == 3);
 
 	libusb_exit(ctx);
 


### PR DESCRIPTION
It's possible that SerialNumber=3 might be received twice due to
differences in timing causing rpiboot to exit too early i.e. before
the second stage has started.

Tweak the loop condition to handle this.