### PR TITLE
Update udev rules to use uaccess tag

### DIFF
--- a/debian/70-rpiboot.rules
+++ b/debian/70-rpiboot.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0a5c", ATTR{idProduct}=="27[16][134]", TAG+="uaccess"

--- a/debian/99-rpiboot.rules
+++ b/debian/99-rpiboot.rules
@@ -1,1 +1,0 @@
-ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0a5c", ATTR{idProduct}=="27[16][134]", GROUP="plugdev"


### PR DESCRIPTION
The recommended way of granting users access to USB devices is not using `GROUP="plugdev"`, but `TAG+="uaccess"`: https://wiki.debian.org/USB/GadgetSetup

More background info about the uaccess tag amd what it does: https://enotty.pipebreaker.pl/2012/05/23/linux-automatic-user-acl-management/