### PR TITLE
Use pkg-config to locate libusb-1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 rpiboot: main.c msd/bootcode.h msd/start.h msd/bootcode4.h msd/start4.h
-	$(CC) -Wall -Wextra -g -o $@ $< -lusb-1.0
+	$(CC) -Wall -Wextra -g -o $@ $< `pkg-config --cflags --libs libusb-1.0`
 
 %.h: %.bin ./bin2c
 	./bin2c $< $@

--- a/Readme.md
+++ b/Readme.md
@@ -28,13 +28,15 @@ From a macOS machine, you can also run usbboot, just follow the same steps:
 
 1. Clone the `usbboot` repository
 2. Install `libusb` (`brew install libusb`)
-3. Build using make
-4. Run the binary
+3. Install `pkg-config` (`brew install pkg-config`)
+4. Build using make
+5. Run the binary
 
 ```
 git clone --depth=1 https://github.com/raspberrypi/usbboot
 cd usbboot
 brew install libusb
+brew install pkg-config
 make
 sudo ./rpiboot
 ```

--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This PR resolves https://github.com/raspberrypi/usbboot/issues/81, and closes https://github.com/raspberrypi/usbboot/pull/25.

This is a very simple change that uses `pkg-config` to locate `libusb-1.0` rather than assuming its path, allowing users who have installed `libusb-1.0` with homebrew to successfully build with `make`.

---

Thanks to @khorben (PR: #25) and @Parnoud (Issue: https://github.com/raspberrypi/usbboot/issues/81#issuecomment-851637615) for laying out the solution.