### PR TITLE
rpiboot: Add build date and version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+PKG_VER=$(shell grep rpiboot debian/changelog | head -n1 | sed 's/.*(\(.*\)).*/\1/g')
+GIT_VER=$(shell git rev-parse HEAD 2>/dev/null | cut -c1-8 || echo "")
 rpiboot: main.c msd/bootcode.h msd/start.h msd/bootcode4.h msd/start4.h
-	$(CC) -Wall -Wextra -g -o $@ $< `pkg-config --cflags --libs libusb-1.0`
+	$(CC) -Wall -Wextra -g -o $@ $< `pkg-config --cflags --libs libusb-1.0` -DGIT_VER="\"$(GIT_VER)\"" -DPKG_VER="\"$(PKG_VER)\""
 
 %.h: %.bin ./bin2c
 	./bin2c $< $@

--- a/main.c
+++ b/main.c
@@ -649,6 +649,8 @@ int main(int argc, char *argv[])
 
 	get_options(argc, argv);
 
+	printf("RPIBOOT: build-date %s version %s %s\n", __DATE__, PKG_VER, GIT_VER);
+
 	// flush immediately
 	setbuf(stdout, NULL);
 


### PR DESCRIPTION
Update rpiboot to emit the build-date and version in order so that this visible in bug reports.
