### PR TITLE
Fixed regex for sig file to replace only extension

### DIFF
--- a/tools/update-pieeprom.sh
+++ b/tools/update-pieeprom.sh
@@ -150,7 +150,7 @@ if [ -z "${PUBLIC_PEM_FILE}" ]; then
     PUBLIC_PEM_FILE="${PEM_FILE}"
 fi
 
-DST_IMAGE_SIG="$(echo "${DST_IMAGE}" | sed 's/\..*//').sig"
+DST_IMAGE_SIG="$(echo "${DST_IMAGE}" | sed 's/\.[^.]*$//').sig"
 
 update_eeprom "${SRC_IMAGE}" "${CONFIG}" "${DST_IMAGE}" "${PEM_FILE}" "${PUBLIC_PEM_FILE}"
 image_digest "${DST_IMAGE}" "${DST_IMAGE_SIG}"

--- a/tools/update-pieeprom.sh
+++ b/tools/update-pieeprom.sh
@@ -150,7 +150,7 @@ if [ -z "${PUBLIC_PEM_FILE}" ]; then
     PUBLIC_PEM_FILE="${PEM_FILE}"
 fi
 
-DST_IMAGE_SIG="$(echo "${DST_IMAGE}" | sed 's/\.[^.]*$//').sig"
+DST_IMAGE_SIG="$(echo "${DST_IMAGE}" | sed 's/\.[^./]*$//').sig"
 
 update_eeprom "${SRC_IMAGE}" "${CONFIG}" "${DST_IMAGE}" "${PEM_FILE}" "${PUBLIC_PEM_FILE}"
 image_digest "${DST_IMAGE}" "${DST_IMAGE_SIG}"


### PR DESCRIPTION
Previously, relative paths would confuse the file name generation regex.
With this change, only the final '.' character is matched as the
beginning of the file extension.