### PR TITLE
tools/update-pieeprom.sh: Fix cleanup exiting 1

### DIFF
--- a/tools/update-pieeprom.sh
+++ b/tools/update-pieeprom.sh
@@ -25,7 +25,7 @@ die() {
 }
 
 cleanup() {
-   [ -f "${TMP_CONFIG}" ] && rm -f "${TMP_CONFIG}"
+   if [ -f "${TMP_CONFIG}" ]; then rm -f "${TMP_CONFIG}"; fi
 }
 
 usage() {


### PR DESCRIPTION
When not signing the configuration (no -k option), there's no
$TMP_CONFIG file and `test -f "$TMP_CONFIG"` is false. The whole line
becomes false and the script exists 1 for `set -e`.

This commit fixes that by moving the test to `if` condition.