### PR TITLE
main: check _POSIX_VERSION for fmemopen

### DIFF
--- a/main.c
+++ b/main.c
@@ -10,9 +10,14 @@
 #include "msd/bootcode4.h"
 #include "msd/start4.h"
 
-/* Assume BSD without native fmemopen() if doesn't seem to be glibc */
-#if defined(__APPLE__) || (!defined(_GNU_SOURCE) && (!defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200809L))
-#include "fmemopen.c" // BSD fmemopen() compat in terms of funopen()
+/*
+ * Old OS X/BSD do not implement fmemopen().  If the version of POSIX
+ * supported is old enough that fmemopen() isn't included, assume
+ * we're on a BSD compatible system and define a fallback fmemopen()
+ * that depends on funopen().
+ */
+#if _POSIX_VERSION <= 200112L
+#include "fmemopen.c"
 #endif
 
 int signed_boot = 0;


### PR DESCRIPTION
Previously two commits added a fallback fmemopen for OS X/BSD that
didn't support fmemopen, then fixed some of the ifdef logic around it.
Unforunately the logic was backwards, as libc implementations do not
define _POSIX_C_SOURCE in order to advertise features.  Instead the
user defines _POSIX_C_SOURCE to control which definitions are
available.

Check _POSIX_VERSION to see if the libc is new enough to implement
fmemopen.  If it is too old, assume that we're on a BSD compatible
system and use the fallback fmemopen that depends on funopen.
This solves the problem for some environments, but is still incorrect
as it will try to use the fallback even on a system that does not
include funopen.

Fixes: 45c7237 (Fixup for recent firmware inclusion changes (#34))
Fixes: 17f6b01 (Fix cross-platform building)
Fixes: #132 (Build failure on musl based system (incorrect fmemopen check))