### PR TITLE
rpi-eeprom-digest: Add an option to verify RSA signed files.

### DIFF
--- a/tools/rpi-eeprom-digest
+++ b/tools/rpi-eeprom-digest
@@ -57,24 +57,59 @@ The bootloader only verifies RSA signatures in signed boot mode
 Examples:
 
 # Generate RSA signature for the EEPROM config file.
-rpi-eeprom-digest -k key.pem -i bootconf.txt  -o bootconf.sig
+rpi-eeprom-digest -k private.pem -i bootconf.txt  -o bootconf.sig
 
 # Generate the normal sha256 hash to guard against file-system corruption
 rpi-eeprom-digest -i pieeprom.bin -o pieeprom.sig
 rpi-eeprom-digest -i vl805.bin -o vl805.sig
 
+# To verify the signature of an existing .sig file using the public key.
+# N.B The key file must be the PUBLIC key in PEM format.
+rpi-eeprom-digest -k public.pem -i pieeprom.bin -v pieeprom.sig
+
 EOF
 exit 0
 }
 
+writeSig() {
+   TMP_DIR=$(mktemp -d)
+   SIG_TMP="${TMP_DIR}/tmp.sig"
+   sha256sum "${IMAGE}" | awk '{print $1}' > "${OUTPUT}"
+
+   # Include the update-timestamp
+   echo "ts: $(date -u +%s)" >> "${OUTPUT}"
+
+   if [ -n "${KEY}" ]; then
+      [ -f "${KEY}" ] || die "RSA private \"${KEY}\" not found"
+      "${OPENSSL}" dgst -sign "${KEY}" -keyform PEM -sha256 -out "${SIG_TMP}" "${IMAGE}"
+      echo "rsa2048: $(xxd -c 4096 -p < "${SIG_TMP}")" >> "${OUTPUT}"
+   fi
+}
+
+verifySig() {
+   TMP_DIR=$(mktemp -d)
+   sig_file="${1}"
+   [ -f "${sig_file}" ] || die "Signature file ${sig_file} not found"
+   sig_hex="$(grep rsa2048 "${sig_file}" | cut -f 2 -d ' ')"
+   echo ${sig_hex} | xxd -c 4096 -p -r > "${TMP_DIR}/sig.bin"
+
+   [ -n "${sig_hex}" ] || die "No RSA signature in ${sig_file}"
+   sha256=$(sha256sum "${IMAGE}" | awk '{print $1}')
+   "${OPENSSL}" dgst -verify "${KEY}" -signature "${TMP_DIR}/sig.bin" "${IMAGE}" || die "${IMAGE} not verified"
+}
+
 OUTPUT=""
-while getopts i:k:ho: option; do
+VERIFY=0
+while getopts i:k:ho:v: option; do
    case "${option}" in
    i) IMAGE="${OPTARG}"
       ;;
    k) KEY="${OPTARG}"
       ;;
    o) OUTPUT="${OPTARG}"
+      ;;
+   v) SIGNATURE="${OPTARG}"
+      VERIFY=1
       ;;
    h) usage
       ;;
@@ -84,25 +119,15 @@ while getopts i:k:ho: option; do
    esac
 done
 
-[ -n "${IMAGE}" ] || usage
-[ -n "${OUTPUT}" ] || usage
-
 trap cleanup EXIT
-
 checkDependencies
 
+[ -n "${IMAGE}" ] || usage
 [ -f "${IMAGE}" ] || die "Source image \"${IMAGE}\" not found"
-
-TMP_DIR=$(mktemp -d)
-SIG_TMP="${TMP_DIR}/tmp.sig"
-sha256sum "${IMAGE}" | awk '{print $1}' > "${OUTPUT}"
-
-# Include the update-timestamp
-echo "ts: $(date -u +%s)" >> "${OUTPUT}"
-
-if [ -n "${KEY}" ]; then
-   [ -f "${KEY}" ] || die "RSA private \"${KEY}\" not found"
-
-   "${OPENSSL}" dgst -sign "${KEY}" -keyform PEM -sha256 -out "${SIG_TMP}" "${IMAGE}"
-   echo "rsa2048: $(xxd -c 4096 -p < "${SIG_TMP}")" >> "${OUTPUT}"
+if [ "${VERIFY}" = 1 ]; then
+   verifySig "${SIGNATURE}"
+else
+   [ -n "${OUTPUT}" ] || usage
+   writeSig
 fi
+


### PR DESCRIPTION
Wrap the OpenSSL commands to verify the RSA signature in a .sig file for a given image. This could be used to verify a signed boot image or EEPROM image before attempting to install it.