### PR TITLE
Fix typo that resulted in opposite meaning (does -> doesn't)

### DIFF
--- a/secure-boot-recovery/README.md
+++ b/secure-boot-recovery/README.md
@@ -70,7 +70,7 @@ onwards:
 
 * The bootloader will only load OS images signed with the customer private key.
 * The EEPROM configuration file must be signed with the customer private key.
-* It is not possible to install an old version of the bootloader that does
+* It is not possible to downgrade to an old version of the bootloader that doesn't
   support secure boot.
 * This option requires EEPROM version 2022-01-06 or newer.
 * BETA bootloader releases are not signed with the ROM secure boot key and will


### PR DESCRIPTION
The old sentence didn't really make sense. Also a bit further down it says "prevents downgrades to bootloader versions that don't support secure boot." which is what the changed sentence was meant to mean. I fixed that and also changed to wording to make it more clear.