### PR TITLE
Update install_script.nsi

### DIFF
--- a/win32/install_script.nsi
+++ b/win32/install_script.nsi
@@ -55,7 +55,7 @@
 ; Initialisation functions
 Function .onInit
 
-  ReadRegStr $R0 HKCU "Software\Compute Module Boot" ""
+  ReadRegStr $R0 HKCU "Software\Raspberry Pi" ""
   StrCmp $R0 "" done
 
   MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \


### PR DESCRIPTION
In commit 467bee5f32bbbe6df2a450eab8fd1230860dfbbb the registry key got changed from "Software\Compute Module Boot" to "Software\Raspberry Pi". In the same commit the .onInit function was added to check whether rpiboot was already installed, but referenced the old key in the registry. The result is that this "already installed" check effectively doesn't happen.