### PR TITLE
rpiboot: Use libusb without prefix

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
My earlier change prefixed the libusb header path in main.c, which matched my environment. To my surprise, something has deposited libusb-1.0.26 into a shared header path - almost certainly not homebrew.

Drop the prefix to force the use of Homebrew's version.