### PR TITLE
rpiboot: Fixup USB VID typo

### DIFF
--- a/main.c
+++ b/main.c
@@ -121,7 +121,7 @@ libusb_device_handle * LIBUSB_CALL open_device_with_serialno(
 				}
 				
 				// Match the magic numbers for Raspberry Pi generations
-				if (desc.idVendor == 0x05ac) {
+				if (desc.idVendor == 0x0a5c) {
 					if (desc.idProduct == 0x2763 ||
 						desc.idProduct == 0x2764 ||
 						desc.idProduct == 0x2711 ||

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@
 #include "fmemopen.c"
 #endif
 
-#define SELECTION_MODE_VID		0
+#define SELECTION_MODE_VID	0
 #define SELECTION_MODE_SERIAL	1
 
 int selection_mode = SELECTION_MODE_VID;
@@ -178,7 +178,7 @@ libusb_device_handle * LIBUSB_CALL open_device_with_serialno(
 					}
 				} else {
 					// Serial number matches, but the VID doesn't. Invalid action.
-					fprintf(stderr, "Unknown USB Vendor ID. Wanted 05ac. Got: %04x\n", desc.idVendor);
+					fprintf(stderr, "Unknown USB Vendor ID. Wanted 0a5c. Got: %04x\n", desc.idVendor);
 					libusb_close(handle);
 					handle = NULL;
 					continue;


### PR DESCRIPTION
It's not 0x05ac, it's 0x0a5c.