### PR TITLE
firmware: Update 2712 to 2024-04-20 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-rpiboot (20240419~110800) UNRELEASED; urgency=medium
+rpiboot (20240422~085300) bookworm; urgency=medium
 
   [ Tim Gover ]
   * bootloader: Update to 2023-01-11 release
@@ -36,6 +36,7 @@ rpiboot (20240419~110800) UNRELEASED; urgency=medium
   * secure-boot-recovery: Document the reboot flag
   * mass-storage-gadget64: Update for CM5
   * BCM2712: Preliminary tool support for secure-boot
+  * firmware: Update 2712 to 2024-04-20 release
 
   [ Torben Woltjen ]
   * Fix typo that resulted in opposite meaning (does -> doesn't)
@@ -68,7 +69,7 @@ rpiboot (20240419~110800) UNRELEASED; urgency=medium
   * rpiboot: Fixup USB VID typo
   * rpiboot: Update 05ac log message
 
- -- Tim Gover <tim.gover@raspberrypi.com>  Fri, 19 Apr 2024 11:02:47 +0100
+ -- Tim Gover <tim.gover@raspberrypi.com>  Mon, 22 Apr 2024 08:53:16 +0100
 
 rpiboot (20221215~105525) bullseye; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: rpiboot
 Section: utils
 Priority: optional
 Maintainer: Serge Schneider <serge@raspberrypi.com>
-Build-Depends: debhelper (>= 9), libusb-1.0-0-dev, pkg-config, rpi-eeprom (>= 22)
+Build-Depends: debhelper (>= 9), libusb-1.0-0-dev, pkg-config, rpi-eeprom (>= 23)
 Standards-Version: 4.5.1
 Homepage: https://github.com/raspberrypi/usbboot
 
 Package: rpiboot
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3, rpi-eeprom (>= 22)
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, rpi-eeprom (>= 23)
 Description: Raspberry Pi USB booting code
  USB MSD boot code which should work on the Raspberry Pi model A,
  Compute Module, Compute Module 3, Compute Module 4, Compute Module 5, Raspberry Pi 5 and Raspberry Pi Zero.

--- a/debian/rpiboot.install
+++ b/debian/rpiboot.install
@@ -11,4 +11,4 @@ secure-boot-msd usr/share/rpiboot/
 tools/update-pieeprom.sh usr/share/rpiboot/tools/
 debian/70-rpiboot.rules /lib/udev/rules.d
 firmware/bootfiles.bin usr/share/rpiboot/firmware/
-firmware/* usr/share/rpiboot/firmware
+temp/firmware/* usr/share/rpiboot/firmware

--- a/debian/rules
+++ b/debian/rules
@@ -11,15 +11,15 @@ override_dh_strip:
 	dh_strip -Xstart.elf -Xstart4.elf
 
 override_dh_install:
-	# Replace the symlinks with specific EEPROM versions
-	rm -rf firmware/2711/recovery.bin firmware/2711/pieeprom.bin
-	rm -rf firmware/2712/recovery.bin firmware/2712/pieeprom.bin
+	# Copy the pinned firmware version
+	rm -rf temp
+	mkdir -p temp/firmware/2711
+	mkdir -p temp/firmware/2712
 
-	cp /lib/firmware/raspberrypi/bootloader-2711/default/pieeprom-2024-04-15.bin firmware/2711/pieeprom.bin
-	cp /lib/firmware/raspberrypi/bootloader-2711/default/recovery.bin firmware/2711/recovery.bin
-
-	cp /lib/firmware/raspberrypi/bootloader-2712/default/pieeprom-2024-04-17.bin firmware/2712/pieeprom.bin
-	cp /lib/firmware/raspberrypi/bootloader-2712/default/recovery.bin firmware/2712/recovery.bin
+	cp firmware/2711/pieeprom.bin temp/firmware/2711/pieeprom.bin
+	cp firmware/2711/recovery.bin temp/firmware/2711/recovery.bin
+	cp firmware/2712/pieeprom.bin temp/firmware/2712/pieeprom.bin
+	cp firmware/2712/recovery.bin temp/firmware/2712/recovery.bin
 	dh_install
 	find $(CURDIR)/debian -name .gitignore -delete
 	rm -rf temp

--- a/firmware/2712/pieeprom-2024-04-17.bin
+++ b/firmware/2712/pieeprom-2024-04-17.bin
@@ -1,1 +1,0 @@
-../../rpi-eeprom/firmware-2712/default/pieeprom-2024-04-17.bin

--- a/firmware/2712/pieeprom.bin
+++ b/firmware/2712/pieeprom.bin
@@ -1,1 +1,1 @@
-../../rpi-eeprom/firmware-2712/latest/pieeprom-2024-04-17.bin
+../../rpi-eeprom/firmware-2712/latest/pieeprom-2024-04-20.bin


### PR DESCRIPTION
Also, slightly simplify the packaging of the firmare to avoid specifying the version number in both the APT meta data and via the symlink.