### PR TITLE
firmware: 2711: Update to latest Pi4 firmware pieeprom-2024-05-17.bin

### DIFF
--- a/firmware/2711/pieeprom.bin
+++ b/firmware/2711/pieeprom.bin
@@ -1,1 +1,1 @@
-../../rpi-eeprom/firmware-2711/default/pieeprom-2024-04-15.bin
+../../rpi-eeprom/firmware-2711/latest/pieeprom-2024-05-17.bin

--- a/firmware/2711/recovery.bin
+++ b/firmware/2711/recovery.bin
@@ -1,1 +1,1 @@
-../../rpi-eeprom/firmware-2711/default/recovery.bin
+../../rpi-eeprom/firmware-2711/latest/recovery.bin


### PR DESCRIPTION
Update to the latest Pi4 firmware/recovery.bin for Pi4B specific OTP provisioning fixes plus improved logging during secure-boot provisioning.