### PR TITLE
firmware: 2711: Move to the 2024-07-30 release

### DIFF
--- a/firmware/2711/pieeprom.bin
+++ b/firmware/2711/pieeprom.bin
@@ -1,1 +1,1 @@
-../../rpi-eeprom/firmware-2711/latest/pieeprom-2024-05-17.bin
+../../rpi-eeprom/firmware-2711/latest/pieeprom-2024-07-30.bin


### PR DESCRIPTION
Move to this release because it resolves some issues booting from the BCM XHCI USB port on CM4 / CM4S.