### PR TITLE
secure-boot: 2712: Update to docs to indicate BETA status

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -193,6 +193,9 @@ to demonstrate the low-level code-signing aspects.
 ** Secure boot [chain of trust diagram](docs/secure-boot-chain-of-trust-2711.pdf).
 ** Secure boot setup [configuration properties](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#secure-boot-configuration-properties-in-config-txt).
 * Secure boot BCM2712
+
+*** WARNING: Secure boot firmware and tooling is currently in BETA on 2712 ***
+
 ** Secure boot [chain of trust diagram](docs/secure-boot-chain-of-trust-2712.pdf).
 ** Secure boot setup [configuration properties](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#secure-boot-configuration-properties-in-config-txt).
 * Device tree [bootloader signed-boot property](https://www.raspberrypi.com/documentation/computers/configuration.html#bcm2711-specific-bootloader-properties-chosenbootloader).

--- a/secure-boot-recovery5/README.md
+++ b/secure-boot-recovery5/README.md
@@ -1,5 +1,7 @@
 # Raspberry Pi 5 - secure boot
 
+*** WARNING: Secure boot firmware and tooling is currently in BETA on 2712 ***
+
 This directory contains the beta bootcode5.bin (recovery.bin) and a pre-release pieeprom.bin
 bootloader release. Older bootloader and recovery.bin releases do not support secure boot.
 


### PR DESCRIPTION
Secure-boot on 2712 is a port of the 2711 functionality. It's in BETA pending security testing and feedback on tooling/provisioning.