### PR TITLE
typo fixes

### DIFF
--- a/mass-storage-gadget64/README.md
+++ b/mass-storage-gadget64/README.md
@@ -37,7 +37,7 @@ branch of the Raspberry Pi [buildroot](https://github.com/raspberrypi/buildroot)
 
 ### Building
 ```bash
-git clone --branch mass-storage-gadget git@github.com:raspberrypi/buildroot.git
+git clone --branch mass-storage-gadget64 git@github.com:raspberrypi/buildroot.git
 cd buildroot
 make raspberrypi64-mass-storage-gadget_defconfig
 make

--- a/secure-boot-recovery5/README.md
+++ b/secure-boot-recovery5/README.md
@@ -23,7 +23,7 @@ option secure-boot can be tested and reverted via `RPIBOOT` at this stage.
 ## Sign the EEPROM and the second stage bootloader
 The BCM2712 boot ROM requires the second stage firmware (recovery.bin / bootcode5.bin) to be counter-signed with the customer private key in secure-mode.
 Pass the `f` flag to enable firmware counter-signing.
-
+```
 ../tools/update-pieeprom.sh -f -k "${KEY_FILE}"
 ```
 


### PR DESCRIPTION
Fix typo in mass-storage-gadget64 and fix formatting in secure-boot-recovery5 README.md