### PR TITLE
make-boot-image: preserve file attributes

### DIFF
--- a/tools/make-boot-image
+++ b/tools/make-boot-image
@@ -89,7 +89,7 @@ copyfiles() {
       mcopy -i "${image}" -vsmpQ "$@" ::/
    else
       mountfs "${image}"
-      cp -rv "$@" "${BOOT_MOUNT}"
+      cp -rpv "$@" "${BOOT_MOUNT}"
       sync
 
       echo "Sync"
@@ -107,7 +107,7 @@ createstaging() {
    board="$3"
 
    mkdir -p "${staging}" || die "Failed to create ${staging}"
-   cp -r "${source_dir}/"* "${staging}"
+   cp -rp "${source_dir}/"* "${staging}"
 
    # Remove files for previous hardware version
    if [ "${board}" = "pi4" ] || [ "${board}" = "pi400" ] || [ "${board}" = "cm4" ]; then


### PR DESCRIPTION
In order to make binary reproducible images, the script must preserve modification time and other properties of the files as they are copied. Both when copying out from the given directory and into the staging directory, and when copying from the staging dir to the final image.

As FAT does not have the concept of symlinks or hardlinks, we do need the copy command to follow symlinks, meaning we cannot have -d in effect, which in turn precludes using the -a option (which is "same as -dR --preserve=all"). So just add the -p flag, meaning "--preserve=mode,ownership,timestamps".