### PR TITLE
debian: Require rpi-eeprom 26.3 or newer for CM5 / Pi500 support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: rpiboot
 Section: utils
 Priority: optional
 Maintainer: Serge Schneider <serge@raspberrypi.com>
-Build-Depends: debhelper (>= 9), libusb-1.0-0-dev, pkg-config, rpi-eeprom (>= 26)
+Build-Depends: debhelper (>= 9), libusb-1.0-0-dev, pkg-config, rpi-eeprom (>= 26.3)
 Standards-Version: 4.5.1
 Homepage: https://github.com/raspberrypi/usbboot
 


### PR DESCRIPTION
These boards require firmware 2024-09-23 or newer.