### PR TITLE
Makefile: make it work better in a cross-build scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
 PKG_VER=$(shell grep rpiboot debian/changelog | head -n1 | sed 's/.*(\(.*\)).*/\1/g')
 GIT_VER=$(shell git rev-parse HEAD 2>/dev/null | cut -c1-8 || echo "")
+HAVE_XXD=$(shell xxd -v >/dev/null 2>/dev/null && echo y)
 INSTALL_PREFIX?=/usr
 
 rpiboot: main.c bootfiles.c decode_duid.c msd/bootcode.h msd/start.h msd/bootcode4.h msd/start4.h
 	$(CC) -Wall -Wextra -g $(CFLAGS) -o $@ main.c bootfiles.c decode_duid.c `pkg-config --cflags --libs libusb-1.0` -DGIT_VER="\"$(GIT_VER)\"" -DPKG_VER="\"$(PKG_VER)\"" -DINSTALL_PREFIX=\"$(INSTALL_PREFIX)\" $(LDFLAGS)
+
+ifeq ($(HAVE_XXD),y)
+%.h: %.bin
+	xxd -i $< > $@
+
+%.h: %.elf
+	xxd -i $< > $@
+else
+CC_FOR_BUILD ?= $(CC)
 
 %.h: %.bin ./bin2c
 	./bin2c $< $@
@@ -12,7 +22,9 @@ rpiboot: main.c bootfiles.c decode_duid.c msd/bootcode.h msd/start.h msd/bootcod
 	./bin2c $< $@
 
 bin2c: bin2c.c
-	$(CC) -Wall -Wextra -g -o $@ $<
+	$(CC_FOR_BUILD) -Wall -Wextra -g -o $@ $<
+
+endif
 
 install: rpiboot
 	install -m 755 rpiboot $(INSTALL_PREFIX)/bin/


### PR DESCRIPTION
Long ago, the makefile logic made use of the xxd tool to generate a C array from a binary file. That was removed in commit 768c0563d110 ("Add cross platform method of building in a binary!"), in favor of the little bin2c helper, presumably because the xxd tool is not necessarily available everywhere.

However, that then introduced the implicit assumption that ${CC} is a compiler meant for producing binaries for the current build host, and thus breaks down in a cross-build setup, such as when trying to integrate this in a Yocto recipe.

Adapt the logic so that when xxd is available, use that, and if not, honour a CC_FOR_BUILD environment variable if set, letting that default to $(CC). This way, a cross-build environment can either make sure to add build-time dependency on xxd-native, or export an appropriate CC_FOR_BUILD variable.