### PR TITLE
mass-storage-gadget64: fix invokes of extra tools in sign.sh

### DIFF
--- a/mass-storage-gadget64/sign.sh
+++ b/mass-storage-gadget64/sign.sh
@@ -47,6 +47,7 @@ trap cleanup EXIT
 KEY_FILE="${1}"
 [ -f "${KEY_FILE}" ] || die "KEY_FILE: ${KEY_FILE} not found"
 
+PATH="${script_dir}/../tools:${PATH}"
 KEY_FILE="${1}"
 TMP_DIR="$(mktemp -d)"
 rm -f bootfiles.bin


### PR DESCRIPTION
`./sign.sh <key>`

produces error:

> Signing OS image /home/kusov/development/usbboot/mass-storage-gadget64/bootfiles.original.bin
> Signing 2712/bootcode5.bin
> Signing firmware in 2712/bootcode5.bin
> ./sign.sh: 20: rpi-sign-bootcode: not found
> Failed to sign bootcode5.bin
