### PR TITLE
win32 - Installer - Update shortcut names to reflected supported HW version

### DIFF
--- a/win32/install_script.nsi
+++ b/win32/install_script.nsi
@@ -125,8 +125,8 @@ Section "Raspberry Pi USB Boot" Sec_rpiboot
   File rpi-mass-storage-gadget64.bat
 
   CreateDirectory "$SMPROGRAMS\Raspberry Pi"
-  CreateShortcut "$SMPROGRAMS\Raspberry Pi\rpiboot.lnk" "$INSTDIR\rpiboot.exe"
-  CreateShortcut "$SMPROGRAMS\Raspberry Pi\Raspberry Pi - Mass Storage Gadget - 64-bit.lnk" "$INSTDIR\rpi-mass-storage-gadget64.bat"
+  CreateShortcut "$SMPROGRAMS\Raspberry Pi\rpiboot-CM-CM2-CM3.lnk" "$INSTDIR\rpiboot.exe"
+  CreateShortcut "$SMPROGRAMS\Raspberry Pi\rpiboot-CM4-CM5 - Mass Storage Gadget.lnk" "$INSTDIR\rpi-mass-storage-gadget64.bat"
   CreateShortcut "$SMPROGRAMS\Raspberry Pi\Uninstall rpiboot.lnk" "$INSTDIR\Uninstall.exe"
 
   ;Store installation folder

--- a/win32/rpi-mass-storage-gadget.bat
+++ b/win32/rpi-mass-storage-gadget.bat
@@ -1,3 +1,0 @@
-@echo off
-@echo USB mass storage gadget for Compute Module 4
-rpiboot -d mass-storage-gadget

--- a/win32/rpi-mass-storage-gadget64.bat
+++ b/win32/rpi-mass-storage-gadget64.bat
@@ -1,3 +1,9 @@
 @echo off
 @echo USB mass storage gadget for Raspberry Pi 5
 rpiboot -d mass-storage-gadget64
+@echo:
+@echo Raspberry Pi Mass Storage Gadget started
+@echo EMMC/NVMe devices should be visible in the Raspberry Pi Imager in a few seconds.
+@echo For debug, you can login to the device using the USB serial gadget - see COM ports in Device Manager.
+@echo: 
+set /p dummy=Press a key to close this window.


### PR DESCRIPTION
Change the shortcut links to indicate that rpiboot.exe should be used for cm-cm2-cm3 and that the mass-storage-gadget should be used for cm4-cm5

Also, update the mass-storage-gadget to provide an information message / prompt after starting the gadget service.