### PR TITLE
2712: Update recommended boot.conf for default provisioning setup

### DIFF
--- a/recovery5/boot.conf
+++ b/recovery5/boot.conf
@@ -1,4 +1,7 @@
 [all]
 BOOT_UART=1
-POWER_OFF_ON_HALT=0
-BOOT_ORDER=0xf461
+POWER_OFF_ON_HALT=1
+
+# Boot Order Codes, from https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#BOOT_ORDER
+# Try SD first (1), followed by, USB PCIe, NVMe PCIe, then network
+BOOT_ORDER=0xf2461

--- a/secure-boot-recovery5/boot.conf
+++ b/secure-boot-recovery5/boot.conf
@@ -4,13 +4,7 @@ POWER_OFF_ON_HALT=1
 
 # Boot Order Codes, from https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#BOOT_ORDER
 # Try SD first (1), followed by, USB (RP1), NVMe PCIe, then network
-BOOT_ORDER=0xf2641
+BOOT_ORDER=0xf2461
 
 # Disable self-update mode - to prevent automatic updates of unsigned bootloader images
 ENABLE_SELF_UPDATE=0
-
-# Select signed-boot mode in the EEPROM. This can be used to during development
-# to test the signed boot image. Once secure boot is enabled via OTP this setting
-# has no effect i.e. it is always 1.
-SIGNED_BOOT=1
-


### PR DESCRIPTION
* Enable network boot
* Fix USB/NVMe order (NVMe should be first)
* Remove redundant SIGNED_BOOT=1 from secure-boot-recovery5
* Set POWER_OFF_ON_HALT=1 - recommended for CM5 which is the primary platform for rpiboot.