### PR TITLE
pi5: Improve path handling if bootfiles.bin is not found

### DIFF
--- a/main.c
+++ b/main.c
@@ -298,14 +298,26 @@ libusb_device_handle * LIBUSB_CALL open_device_with_vid(
 				if (bcm2712 && !directory) {
 					directory = INSTALL_PREFIX "/share/rpiboot/mass-storage-gadget64/";
 					use_bootfiles = 1;
-					snprintf(bootfiles_path, sizeof(bootfiles_path),"%s/%s", directory, "bootfiles.bin");
-					printf("2712: Directory not specified using default %s\n", directory);
+					snprintf(bootfiles_path, sizeof(bootfiles_path),"%s%s", directory, "bootfiles.bin");
+					printf("2712: Directory not specified - trying default %s\n", directory);
+
+					fp_second_stage = check_file(directory, second_stage, 1);
+					if (!fp_second_stage)
+					{
+						directory = "mass-storage-gadget64/";
+						snprintf(bootfiles_path, sizeof(bootfiles_path),"%s%s", directory, "bootfiles.bin");
+						printf("2712: trying local path %s\n", directory);
+						fp_second_stage = check_file(directory, second_stage, 1);
+					}
+				}
+				else {
+					fp_second_stage = check_file(directory, second_stage, 1);
 				}
 
-				fp_second_stage = check_file(directory, second_stage, 1);
 				if (!fp_second_stage)
 				{
-					fprintf(stderr, "Failed to open %s\n", second_stage);
+					fprintf(stderr, "Failed to open second stage bootloader (%s)\n", second_stage);
+					fprintf(stderr, "\nPlease try specifying the directory e.g. rpiboot -d mass-storage-gadget64\n");
 					exit(1);
 				}
 
@@ -1027,7 +1039,7 @@ int main(int argc, char *argv[])
 	{
 		int last_serial = -1;
 
-		printf("Waiting for BCM2835/6/7/2711/2712...\n");
+		printf("Waiting for BCM2835/6/7/2711/2712...\n\n");
 
 		// Wait for a device to get plugged in
 		do


### PR DESCRIPTION
Extend the directory search to try ./mass-storage-gadget64 if the -d argument is not specified and the directory is not specified in the install directory.

Improve the error message to suggest passing the -d argument.