### PR TITLE
mass-storage-64: Restore symlink to bootfiles.bin

### DIFF
--- a/mass-storage-gadget64/bootfiles.bin
+++ b/mass-storage-gadget64/bootfiles.bin
@@ -1,0 +1,1 @@
+../firmware/bootfiles.bin


### PR DESCRIPTION
Fixes: https://github.com/raspberrypi/usbboot/issues/275