### PR TITLE
Add `rpiboot` to the apt install dependencies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ Make sure that the system date is set correctly, otherwise Git may produce an er
   is included as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
 
 ```bash
-sudo apt install git libusb-1.0-0-dev pkg-config build-essential
+sudo apt install git libusb-1.0-0-dev pkg-config build-essential rpiboot
 git clone --recurse-submodules --shallow-submodules --depth=1 https://github.com/raspberrypi/usbboot
 cd usbboot
 make


### PR DESCRIPTION
Without `rpiboot` installed, the current instructions fail with:

```
RPIBOOT: build-date Feb 24 2025 version 20240422~085300 e3e95450

Please fit the EMMC_DISABLE / nRPIBOOT jumper before connecting the power and USB cables to the target device.
If the device fails to connect then please see https://rpltd.co/rpiboot for debugging tips.

Waiting for BCM2835/6/7/2711/2712...

Directory not specified - trying default /usr/share/rpiboot/mass-storage-gadget64/
read_file: Failed to read "2711/bootcode4.bin" from "/usr/share/rpiboot/mass-storage-gadget64/bootfiles.bin" - No such file or directory
Loading embedded: bootcode4.bin
Sending bootcode.bin
Successful read 4 bytes
Waiting for BCM2835/6/7/2711/2712...

read_file: Failed to read "2711/bootcode4.bin" from "/usr/share/rpiboot/mass-storage-gadget64/bootfiles.bin" - No such file or directory
Loading embedded: bootcode4.bin
Second stage boot server
read_file: Failed to read "2711/config.txt" from "/usr/share/rpiboot/mass-storage-gadget64/bootfiles.bin" - No such file or directory
Cannot open file config.txt
read_file: Failed to read "2711/pieeprom.sig" from "/usr/share/rpiboot/mass-storage-gadget64/bootfiles.bin" - No such file or directory
Cannot open file pieeprom.sig
read_file: Failed to read "2711/start4.elf" from "/usr/share/rpiboot/mass-storage-gadget64/bootfiles.bin" - No such file or directory
Loading embedded: start4.elf
File read: start4.elf
read_file: Failed to read "2711/fixup4.dat" from "/usr/share/rpiboot/mass-storage-gadget64/bootfiles.bin" - No such file or directory
Cannot open file fixup4.dat
Package configuration
```