### PR TITLE
Pi Zero 2 W Debian Packaging Changes

### DIFF
--- a/debian/70-rpiboot.rules
+++ b/debian/70-rpiboot.rules
@@ -1,1 +1,7 @@
 ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0a5c", ATTR{idProduct}=="27[16][1234]", TAG+="uaccess"
+
+# Disable mass-storage interface if it's made available by the boot rom, it's
+# of no use.
+ACTION=="add", DRIVER=="usb-storage", \
+  ATTRS{idVendor}=="0a5c", ATTRS{idProduct}=="27[16][1234]", \
+  ATTR{authorized}="0"

--- a/debian/rpiboot.install
+++ b/debian/rpiboot.install
@@ -5,6 +5,7 @@ recovery usr/share/rpiboot/
 recovery5 usr/share/rpiboot/
 mass-storage-gadget usr/share/rpiboot/
 mass-storage-gadget64 usr/share/rpiboot/
+mass-storage-gadget64-cm3 usr/share/rpiboot/
 secure-boot-recovery usr/share/rpiboot/
 secure-boot-recovery5 usr/share/rpiboot/
 secure-boot-msd usr/share/rpiboot/


### PR DESCRIPTION
Ensure that bootrom mass storage device is not marked as authorized.

Package mass-storage-gadget64-cm3