### PR TITLE
Update Makefile to handle `date` for macOS compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 BUILD_TIMESTAMP ?= $(shell date -u +%s)
-BUILD_DATE ?= $(shell date "+%Y/%m/%d" --date=@$(BUILD_TIMESTAMP))
+ifeq ($(shell uname),Darwin)
+    BUILD_DATE ?= $(shell date -j -f %s $(BUILD_TIMESTAMP) "+%Y/%m/%d")
+else
+    BUILD_DATE ?= $(shell date "+%Y/%m/%d" --date=@$(BUILD_TIMESTAMP))
+endif
 PKG_VER=$(shell if [ -f debian/changelog ]; then grep rpiboot debian/changelog | head -n1 | sed 's/.*(\(.*\)).*/\1/g'; else echo local; fi)
 GIT_VER=$(shell git rev-parse HEAD 2>/dev/null | cut -c1-8 || echo "")
 HAVE_XXD=$(shell xxd -v >/dev/null 2>/dev/null && echo y)


### PR DESCRIPTION
Modified the BUILD_DATE variable in the Makefile to use the appropriate date command for macOS, ensuring build runs on OSx.

Was otherwise failing with:
```sh
xxd -i msd/bootcode.bin > msd/bootcode.h
xxd -i msd/start.elf > msd/start.h
xxd -i msd/bootcode4.bin > msd/bootcode4.h
date: illegal time format
usage: date [-jnRu] [-I[date|hours|minutes|seconds]] [-f input_fmt]
            [-r filename|seconds] [-v[+|-]val[y|m|w|d|H|M|S]]
            [[[[mm]dd]HH]MM[[cc]yy][.SS] | new_date] [+output_fmt]
cc -Wall -Wextra -g   -o rpiboot main.c bootfiles.c decode_duid.c `pkg-config --cflags --libs libusb-1.0` -DGIT_VER="\"5a62a2cc\"" -DPKG_VER="\"local\"" -DBUILD_DATE="\"\"" -DINSTALL_PREFIX=\"/usr/local\" 
```