### PR TITLE
Add a Hardware Security Module wrapper script interface

### DIFF
--- a/mass-storage-gadget64/README.md
+++ b/mass-storage-gadget64/README.md
@@ -26,6 +26,10 @@ The `sign.sh` script wraps the command do this on Pi4 and Pi5.
 KEY_FILE=$HOME/private.pem
 ./sign.sh ${KEY_FILE}
 ```
+or as follows if using a HSM wrapper script.
+```bash
+./sign.sh -H hsm-wrapper public.pem
+```
 
 WARNING: The signed images will not be bootable on a Pi5 without secure-boot enabled. Run `./reset.sh` to reset the signed images to the default unsigned state.
 

--- a/mass-storage-gadget64/sign.sh
+++ b/mass-storage-gadget64/sign.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
 set -e
+set -u
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 TMP_DIR=""
+SIGN_ARGS=""
+PUBLIC_KEY=""
 
 die() {
    echo "$@" >&2
@@ -15,15 +18,14 @@ cleanup() {
 }
 
 sign_firmware_blob() {
-   echo "Signing firmware in ${1}"
-   [ -f "${KEY_FILE}" ] || die "sign-firmware: key-file ${KEY_FILE} not found"
+   echo "Signing firmware in ${1} using $(which rpi-sign-bootcode)"
    rpi-sign-bootcode \
       -c 2712 \
       -i "${1}" \
       -o "${2}" \
       -n 16 \
       -v 0 \
-      -k "${KEY_FILE}"
+      ${SIGN_ARGS} ${PUBLIC_KEY}
 }
 
 sign_bootfiles() {
@@ -34,25 +36,36 @@ sign_bootfiles() {
       cd "${TMP_DIR}"
       tar -xf "${input}"
       echo "Signing 2712/bootcode5.bin"
-      sign_firmware_blob 2712/bootcode5.bin 2712/bootcode5.bin.signed "${KEY_FILE}" || die "Failed to sign bootcode5.bin"
+      sign_firmware_blob 2712/bootcode5.bin 2712/bootcode5.bin.signed || die "Failed to sign bootcode5.bin"
       mv -f "2712/bootcode5.bin.signed" "2712/bootcode5.bin"
       tar -cf "${output}" *
       find .
    )
-
 }
 
 trap cleanup EXIT
 
-KEY_FILE="${1}"
-[ -f "${KEY_FILE}" ] || die "KEY_FILE: ${KEY_FILE} not found"
+if [ "${1}" = "-H" ]; then
+   HSM_WRAPPER="${2}"
+   PUBLIC_KEY="${3}"
+   [ -f "${PUBLIC_KEY}" ] || die "HSM requires a public key file in PEM format. Public key \"${PUBLIC_KEY}\" not found."
+   PUBLIC_KEY="-p ${3}"
+   if ! command -v "${HSM_WRAPPER}"; then
+      die "HSM wrapper script \"${HSM_WRAPPER}\" not found"
+   fi
+   SIGN_ARGS="-H ${HSM_WRAPPER}"
+else
+   KEY_FILE="${1}"
+   [ -f "${KEY_FILE}" ] || die "KEY_FILE: ${KEY_FILE} not found"
+   SIGN_ARGS="-k ${KEY_FILE}"
+fi
 
 PATH="${script_dir}/../tools:${PATH}"
 KEY_FILE="${1}"
 TMP_DIR="$(mktemp -d)"
 rm -f bootfiles.bin
 ln -sf ../firmware/bootfiles.bin bootfiles.original.bin
-sign_bootfiles "$(pwd)/bootfiles.original.bin" "$(pwd)/bootfiles.bin" "${KEY_FILE}"
+sign_bootfiles "$(pwd)/bootfiles.original.bin" "$(pwd)/bootfiles.bin"
 
-echo "Signing boot.img with ${KEY_FILE}"
-rpi-eeprom-digest -i boot.img -o boot.sig -k "${KEY_FILE}"
+echo "Signing boot.img with ${SIGN_ARGS}"
+rpi-eeprom-digest -i boot.img -o boot.sig ${SIGN_ARGS}

--- a/secure-boot-example/example-hsm-wrapper
+++ b/secure-boot-example/example-hsm-wrapper
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -e
+set -u
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+KEY="${script_dir}/example-private.pem"
+ALGORITHM=""
+OPENSSL=${OPENSSL:-openssl}
+
+die() {
+   echo "$@" >&2
+   exit 1
+}
+
+usage() {
+   cat << EOF
+Example HSM Wrapper Interface
+============================
+This is an example program to demonstrate the HSM wrapper interface for secure boot signing.
+It signs the provided input file using RSA2048 with SHA256 and outputs the PKCS#1 v1.5 signature in hex format.
+
+This program should be used as a template to implement a HSM wrapper for a specific HSM
+and be in the PATH of the user running rpi-eeprom-digest / rpi-sign-bootcode.
+
+Usage: $(basename $0) -a ALGORITHM INPUT_FILE
+
+Options:
+  -a ALGORITHM   The signing algorithm to use (currently only supports rsa2048-sha256)
+  INPUT_FILE     The input file to sign
+  -h             Display this help message
+
+Output:
+  The script outputs the RSA signature in hexadecimal format to stdout.
+  This is the format expected by the rpi-sign-bootcode tool when using an HSM wrapper.
+
+Example:
+  $(basename $0) -a rsa2048-sha256 input.bin > signature.hex
+EOF
+   exit 1
+}
+
+while getopts "a:h" opt; do
+   case "${opt}" in
+      a) ALGORITHM="${OPTARG}"
+         ;;
+      h) usage
+         ;;
+      *) usage
+         ;;
+   esac
+done
+
+# Shift past the options
+shift $((OPTIND-1))
+
+# Check for mandatory arguments
+[ -n "${ALGORITHM}" ] || die "$(basename $0): Algorithm (-a) is required"
+[ $# -eq 1 ] || die "$(basename $0): Input file must be specified as a positional argument"
+
+# Get the input file from positional argument
+IMAGE="$1"
+
+# Validate algorithm
+if [ "${ALGORITHM}" != "rsa2048-sha256" ]; then
+   die "$(basename $0): Unsupported algorithm '${ALGORITHM}'. Only rsa2048-sha256 is supported"
+fi
+
+# Validate input file
+[ -f "${IMAGE}" ] || die "$(basename $0): Input file ${IMAGE} not found"
+
+# Sign the file using the specified algorithm
+${OPENSSL} dgst -hex -sign "${KEY}" -sha256 "${IMAGE}" | awk '{print $2}'

--- a/secure-boot-recovery5/README.md
+++ b/secure-boot-recovery5/README.md
@@ -14,32 +14,47 @@ Alternatively, specify the path when invoking the helper scripts.
 export KEY_FILE="${HOME}/private.pem"
 ```
 
-## Optional. Customize the EEPROM config.
-Custom with the desired bootloader settings.
+## Optional. Customise the EEPROM config.
+Customise with the desired bootloader settings.
 See: [Bootloader configuration](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#raspberry-pi-bootloader-configuration)
 
-Setting `SIGNED_BOOT=1` enables signed-boot mode so that the bootloader will only
-boot.img files signed with the specified RSA key. Since this is an EEPROM config
-option secure-boot can be tested and reverted via `RPIBOOT` at this stage.
-
 ## Sign the EEPROM and the second stage bootloader
-The BCM2712 boot ROM requires the second stage firmware (recovery.bin / bootcode5.bin) to be counter-signed with the customer private key in secure-mode.
+The BCM2712 boot ROM requires the second-stage firmware (recovery.bin / bootcode5.bin) to be counter-signed with the customer private key in secure-boot mode.
 Pass the `f` flag to enable firmware counter-signing.
+
+### Using a private key file
 ```
 ../tools/update-pieeprom.sh -f -k "${KEY_FILE}"
 ```
 
-If secure-boot has already been enabled on the device then `recovery.bin` must then also be counter-signed.
+If secure-boot has already been enabled on the device, then `recovery.bin` must also be counter-signed.
 However, booting a counter-signed `recovery.bin` image on a fresh board without secure-boot enabled will fail
 because the ROM is effectively checking this against a key hash of zero.
 ```
 ../tools/update-pieeprom.sh -fr -k "${KEY_FILE}"
 ```
 
+### Using an HSM wrapper
+When using a Hardware Security Module (HSM), you need to provide both the HSM wrapper script and the corresponding public key:
+
+```
+../tools/update-pieeprom.sh -f -H hsm-wrapper -p public.pem
+```
+
+For recovery.bin signing with HSM:
+```
+../tools/update-pieeprom.sh -fr -H hsm-wrapper -p public.pem
+```
+
+The HSM wrapper script should:
+- Take a single argument which is a temporary filename containing the data to sign
+- Output the PKCS#1 v1.5 signature in hex format
+- Return a non-zero exit code if signing fails
+
 `pieeprom.bin` can then be flashed to the bootloader EEPROM via `rpiboot`.
 
-## Program the EEPROM image using rpiboot
-* Power off DUT
+## Programming the EEPROM image using rpiboot
+* Power off the device
 * Set nRPIBOOT jumper (or hold power button before power on) and remove EEPROM WP protection
 ```bash
 cd secure-boot-recovery5
@@ -53,28 +68,28 @@ can be locked into secure-boot mode.  This writes the hash of the
 customer public key to "one time programmable" (OTP) bits. From then
 onwards:
 
-* The 2712 boot ROM verifies that the secondstage firmware (recovery.bin / bootsys) are
+* The 2712 boot ROM verifies that the second-stage firmware (recovery.bin / bootsys) is
   signed with the customer private key in addition to the Raspberry Pi private key.
 * The bootloader will only load OS images signed with the customer private key.
 * The EEPROM configuration file must be signed with the customer private key.
 * It is not possible to downgrade to an old version of the bootloader that doesn't
   support secure boot.
 
-**WARNING: Modifications to OTP are irreversible. Once `revoke_devkey` has been set it is not possible to unlock secure-boot mode or use a different private key.**
+**WARNING: Modifications to OTP are irreversible. Once `revoke_devkey` has been set, it is not possible to unlock secure-boot mode or use a different private key.**
 
-To enable this edit the `config.txt` file in this directory and set
+To enable this, edit the `config.txt` file in this directory and set
 `program_pubkey=1`
 
 * `program_pubkey` - If 1, write the hash of the customer's public key to OTP.
 
-## Revoking the dev key - NOT SUPPORTED YET
-* `revoke_devkey` - If 1, revoke the ROM bootloader development key which
+## Revoking the development key - NOT SUPPORTED YET
+* `revoke_devkey` - If 1, revoke the ROM bootloader development key, which
    requires secure-boot mode and prevents downgrades to bootloader versions that
-    don't support secure boot.
+   don't support secure boot.
 
 ## Disabling VideoCore JTAG
 
 VideoCore JTAG may be permanently disabled by setting `program_jtag_lock` in
-`config.txt`.  This option has no effect unless the public key hash (`program_pubkey`) has been successfully programmed.
+`config.txt`. This option has no effect unless the public key hash (`program_pubkey`) has been successfully programmed.
 
 See [config.txt](config.txt)

--- a/test/validate-hsm-wrapper.sh
+++ b/test/validate-hsm-wrapper.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+
+# Script to validate that the example-hsm-wrapper produces bitwise identical
+# signatures to direct signing with the private key
+
+set -e
+set -u
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+export PATH="${script_dir}/../tools:${PATH}"
+
+# Set SOURCE_DATE_EPOCH to current timestamp to ensure consistent timestamps
+export SOURCE_DATE_EPOCH=$(date +%s)
+echo "Using timestamp: ${SOURCE_DATE_EPOCH}"
+
+sign_firmware_blob() {
+   echo "Signing firmware in ${1} using $(which rpi-sign-bootcode)"
+   rpi-sign-bootcode \
+      -c 2712 \
+      -i "${1}" \
+      -o "${2}" \
+      -n 16 \
+      -v 0 \
+      ${SIGN_ARGS} ${PUBLIC_KEY}
+}
+
+cleanup() {
+   if [ -n "${TMP_DIR:-}" ] && [ -d "${TMP_DIR}" ]; then
+      echo "Cleaning up temporary directory: ${TMP_DIR}"
+      rm -rf "${TMP_DIR}"
+   fi
+}
+
+# Get the script directory
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+USBBOOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+HSM_WRAPPER="${USBBOOT_DIR}/secure-boot-example/example-hsm-wrapper"
+PRIVATE_KEY="${USBBOOT_DIR}/secure-boot-example/example-private.pem"
+PUBLIC_KEY="-p ${USBBOOT_DIR}/secure-boot-example/example-public.pem"
+FIRMWARE_DIR="${USBBOOT_DIR}/firmware"
+RECOVERY_DIR="${USBBOOT_DIR}/secure-boot-recovery5"
+
+# Check if bootfiles.bin exists
+if [ ! -f "${FIRMWARE_DIR}/bootfiles.bin" ]; then
+    echo "ERROR: bootfiles.bin not found in ${FIRMWARE_DIR}"
+    echo "Please make sure the firmware directory contains bootfiles.bin"
+    exit 1
+fi
+
+# Check if pieeprom.original.bin exists
+if [ ! -f "${RECOVERY_DIR}/pieeprom.original.bin" ]; then
+    echo "ERROR: pieeprom.original.bin not found in ${RECOVERY_DIR}"
+    echo "Please make sure the secure-boot-recovery5 directory contains pieeprom.original.bin"
+    exit 1
+fi
+
+# Create a temporary directory for our test files
+TMP_DIR=$(mktemp -d)
+trap cleanup EXIT
+
+test_sign_bootcode() {
+    echo ""
+    echo "======================================================================"
+    echo "TEST: BOOTCODE SIGNING COMPARISON"
+    echo "======================================================================"
+    echo ""
+
+    # Copy bootfiles.bin to our test directory
+    BOOTFILES="${TMP_DIR}/bootfiles.bin"
+    cp "${FIRMWARE_DIR}/bootfiles.bin" "${BOOTFILES}"
+
+    # Extract bootcode5.bin from bootfiles.bin using tar
+    echo "Extracting 2712/bootcode5.bin from bootfiles.bin"
+    cd "${TMP_DIR}"
+    tar -xf "${BOOTFILES}" 2712/bootcode5.bin
+    BOOTCODE="${TMP_DIR}/2712/bootcode5.bin"
+
+    if [ ! -f "${BOOTCODE}" ]; then
+        echo "ERROR: Failed to extract 2712/bootcode5.bin from bootfiles.bin"
+        exit 1
+    fi
+
+    # Sign using private key mode
+    echo ""
+    echo "----------------------------------------------------------------------"
+    echo "PRIVATE KEY SIGNING MODE"
+    echo "----------------------------------------------------------------------"
+    echo ""
+    SIGN_ARGS="-k ${PRIVATE_KEY}"
+    PRIVATE_SIGNED="${TMP_DIR}/bootcode5.private.signed"
+    sign_firmware_blob "${BOOTCODE}" "${PRIVATE_SIGNED}"
+
+    # Sign using HSM wrapper mode
+    echo ""
+    echo "----------------------------------------------------------------------"
+    echo "HSM WRAPPER SIGNING MODE"
+    echo "----------------------------------------------------------------------"
+    echo ""
+    SIGN_ARGS="-H ${HSM_WRAPPER}"
+    HSM_SIGNED="${TMP_DIR}/bootcode5.hsm.signed"
+    sign_firmware_blob "${BOOTCODE}" "${HSM_SIGNED}"
+
+    # Compare the signed files
+    echo ""
+    echo "----------------------------------------------------------------------"
+    echo "COMPARING SIGNED FILES"
+    echo "----------------------------------------------------------------------"
+    echo ""
+    if cmp -s "${PRIVATE_SIGNED}" "${HSM_SIGNED}"; then
+        echo "SUCCESS: HSM wrapper and private key signing produce identical output"
+        return 0
+    else
+        echo "ERROR: HSM wrapper and private key signing produce different output"
+        echo "Files differ. Check the following files for details:"
+        echo "  Private key signed: ${PRIVATE_SIGNED}"
+        echo "  HSM wrapper signed: ${HSM_SIGNED}"
+        return 1
+    fi 
+}
+
+test_sign_eeprom() {
+    echo ""
+    echo "======================================================================"
+    echo "TEST: EEPROM SIGNING COMPARISON"
+    echo "======================================================================"
+    echo ""
+    
+    # Create a test directory for EEPROM signing
+    EEPROM_TEST_DIR="${TMP_DIR}/eeprom_test"
+    mkdir -p "${EEPROM_TEST_DIR}"
+    
+    # Copy pieeprom.original.bin to our test directory
+    cp "${RECOVERY_DIR}/pieeprom.original.bin" "${EEPROM_TEST_DIR}/"
+    cp "${RECOVERY_DIR}/recovery.original.bin" "${EEPROM_TEST_DIR}/"
+    
+    # Create a minimal boot.conf file
+    cat > "${EEPROM_TEST_DIR}/boot.conf" << EOF
+[all]
+BOOT_UART=1
+POWER_OFF_ON_HALT=1
+EOF
+    
+    # Sign using private key mode
+    echo ""
+    echo "----------------------------------------------------------------------"
+    echo "PRIVATE KEY SIGNING MODE"
+    echo "----------------------------------------------------------------------"
+    echo ""
+    cd "${EEPROM_TEST_DIR}"
+    update-pieeprom.sh -c boot.conf -k "${PRIVATE_KEY}" -f -o pieeprom.private.bin
+    PRIVATE_SIGNED="${EEPROM_TEST_DIR}/pieeprom.private.bin"
+    
+    # Sleep to verify that SOURCE_DATE_EPOCH is used
+    sleep 1
+
+    # Sign using HSM wrapper mode
+    echo ""
+    echo "----------------------------------------------------------------------"
+    echo "HSM WRAPPER SIGNING MODE"
+    echo "----------------------------------------------------------------------"
+    echo ""
+    cd "${EEPROM_TEST_DIR}"
+    update-pieeprom.sh -c boot.conf -H "${HSM_WRAPPER}" -p "${USBBOOT_DIR}/secure-boot-example/example-public.pem" -f -o pieeprom.hsm.bin
+    HSM_SIGNED="${EEPROM_TEST_DIR}/pieeprom.hsm.bin"
+    
+    # Compare the signed files
+    echo ""
+    echo "----------------------------------------------------------------------"
+    echo "COMPARING SIGNED FILES"
+    echo "----------------------------------------------------------------------"
+    echo ""
+    if cmp -s "${PRIVATE_SIGNED}" "${HSM_SIGNED}"; then
+        echo "SUCCESS: HSM wrapper and private key signing produce identical EEPROM output"
+        return 0
+    else
+        echo "ERROR: HSM wrapper and private key signing produce different EEPROM output"
+        echo "Files differ. Check the following files for details:"
+        echo "  Private key signed: ${PRIVATE_SIGNED}"
+        echo "  HSM wrapper signed: ${HSM_SIGNED}"
+        return 1
+    fi
+}
+
+# Run the tests
+test_sign_bootcode
+test_sign_eeprom


### PR DESCRIPTION
Add support for HSMs by extracting by adding an interface where the PKCS#1 v1.5 signature (RSA2048 SHA256) generation can be implemented by a dedicated helper script.

This approach makes it easier to support multiple HSM APIs without adding specific knowledge of HSMs to this code.

The algorithm choice is provided by the API but is very unlikely to change because that would require updating the BCM2711 / BCM2712 bootroms.

A software implemenation (secure-boot-example/example-hsm-wrapper) is provided to define the interface and act as reference for unit tests.