### PR TITLE
secure-boot-recovery: program_pubkey now automatically sets revoke_devkey=1

### DIFF
--- a/secure-boot-recovery/.gitignore
+++ b/secure-boot-recovery/.gitignore
@@ -1,2 +1,3 @@
 pieeprom.bin
 pieeprom.sig
+metadata/

--- a/secure-boot-recovery/README.md
+++ b/secure-boot-recovery/README.md
@@ -60,9 +60,51 @@ cd secure-boot-recovery
 ## Program the EEPROM image using rpiboot
 * Power off CM4
 * Set nRPIBOOT jumper and remove EEPROM WP protection
+* If possible connect a UART to the CM4 and capture the output for debug
+
 ```bash
 cd secure-boot-recovery
-../rpiboot -d .
+mkdir -p metadata
+../rpiboot -d . -j metadata
+```
+
+### Example UART output
+```
+
+148.84 Verify BOOT EEPROM
+148.85 Reading EEPROM: 524288 bytes 0xc0b60000
+148.35 645ms
+149.89 BOOT-EEPROM: UPDATED
+149.08 secure_boot_provision program_pubkey 1
+149.09 bootconf.sig
+149.09 hash: b503f8ad7f8aea93a272a5ba5248cc5222d0c55af28a4345d0a496bdba9d16bf
+149.10 rsa2048: 612bda4eee969ef9f3e1a651cc4ae6f8b5c5e1eef436e0ff80a4bea2e70bb163b1a54e1376be04a248d7a1f52256bcf0f3dab71b93fb344d7200b61f1020f4620e7ad587cf7fbc35a10b7cd928fe6e3e239d6a7b17a0fd62ddf49ac5fc667686fb43be4b24811a8e1b6e31de525dd2f31ac851f5a19815aa85f9755456610161e034ff7672fd69d567c159d84f703bfbdd76c9a6ec3804236d3dd5550f09d083521d4f6cb6f50ab1ada7c37090a6bc8e306690f04d06dab02b0b80027c9cd27bef18be14f771bb4841bf5a285fadc2731278fc73efccbab1f60fd58c3ada1b35f6a11e9862b5eacdcff420c827f33b498fc2782659e1bcf35bf1ef02adb46c28
+149.14 RSA verify
+149.81 rsa-verify pass (0x0)
+149.18 Public key hash 8251a63a2edee9d8f710d63e9da5d639064929ce15a2238986a189ac6fcd3cee
+149.19 OTP-WR: boot-mode 000048b0
+149.19 OTP-WR: boot-mode 000048b0
+149.19 OTP-WR: flags 00000081
+149.19 Write OTP key
+149.22 OTP updated for key 8251a63a2edee9d8f710d63e9da5d639064929ce15a2238986a189ac6fcd3cee
+149.23 Revoke development key
+```
+
+### Metadata
+The optional metadata argument causes rpiboot to readback the OTP information and write it to a JSON file in the given directory.
+This can be useful for debug or for storing in a provisioning database.
+
+Example metadata:
+```json
+{
+        "MAC_ADDR" : "d8:3a:dd:05:ee:78",
+        "CUSTOMER_KEY_HASH" : "8251a63a2edee9d8f710d63e9da5d639064929ce15a2238986a189ac6fcd3cee",
+        "BOOT_ROM" : "0000c8b0",
+        "BOARD_ATTR" : "00000000",
+        "USER_BOARDREV" : "c03141",
+        "JTAG_LOCKED" : "0",
+        "ADVANCED_BOOT" : "0000e8e8"
+}
 ```
 * Power ON CM4
 
@@ -74,22 +116,13 @@ onwards:
 
 * The bootloader will only load OS images signed with the customer private key.
 * The EEPROM configuration file must be signed with the customer private key.
-* It is not possible to downgrade to an old version of the bootloader that doesn't
-  support secure boot.
+* It is not possible to downgrade to an old version of the bootloader that doesn't support secure boot.
 
-**WARNING: Modifications to OTP are irreversible. Once `revoke_devkey` has been set it is not possible to unlock secure-boot mode or use a different private key.**
-
-To enable this edit the `config.txt` file in this directory and set
-`program_pubkey=1`
-
-* `program_pubkey` - If 1, write the hash of the customer's public key to OTP.
-* `revoke_devkey` - If 1, revoke the ROM bootloader development key which
-   requires secure-boot mode and prevents downgrades to older bootloader versions that don't support secure boot.
+To enable this edit the `config.txt` file in this directory and set `program_pubkey=1`
 
 ## Disabling VideoCore JTAG
 
 VideoCore JTAG may be permanently disabled by setting `program_jtag_lock` in
-`config.txt`. This option has no effect unless `revoke_devkey=1` is set and
-the EEPROM and customer OTP key were programmed successfully.
+`config.txt`. This option has no effect unless secure-boot has been enabled.
 
 See [config.txt](config.txt)

--- a/secure-boot-recovery/boot.conf
+++ b/secure-boot-recovery/boot.conf
@@ -11,8 +11,12 @@ BOOT_ORDER=0xf25641
 # Disable self-update mode
 ENABLE_SELF_UPDATE=0
 
-# Select signed-boot mode in the EEPROM. This can be used to during development
-# to test the signed boot image. Once secure boot is enabled via OTP this setting
-# has no effect i.e. it is always 1.
+# Setting SIGNED_BOOT=1 causes the bootloader to required signed boot.img files
+# which can be used to test that boot.img files are signed correctly.
+#
+# This setting does NOT enable secure-boot and can be switched off.
+#
+# If secure-boot is enabled via program_pubkey=1 then SIGNED_BOOT=1 is implicitly set
+# and cannot be unset.
 SIGNED_BOOT=1
 

--- a/secure-boot-recovery/config.txt
+++ b/secure-boot-recovery/config.txt
@@ -11,18 +11,12 @@ uart_2ndstage=1
 # This option also prevents the ROM from loading recovery.bin from SD/EMMC
 # which means that the bootloader can only be updated via RPIBOOT or self-update.
 #
+# recovery.bin version to 2025-05-15 and newer automatically sets
+# revoke_devkey=1 if program_pubkey is non-zero.
+#
 # Uncomment program_pubkey=1 to enable this
 # WARNING: THIS OPTION MODIFIES THE BCM2711 CHIP AND IS IRREVERSIBLE.
-
 #program_pubkey=1
-
-# Uncomment to revoke the ROM development key via OTP preventing older
-# bootloader or recovery.bin releases from running on this Pi
-# WARNING: THIS OPTION MODIFIES THE BCM2711 CHIP AND IS IRREVERSIBLE.
-#
-# DO NOT SET THIS OPTION UNTIL THE BOOTLOADER IS SIGNED WITH THE SECURE
-# BOOT KEY. IT WILL PREVENT THE PI FROM BOOTING.
-#revoke_devkey=1
 
 # Pi 4B and Pi400 do not have a dedicated RPIBOOT jumper so a different GPIO
 # must be used to enable RPIBOOT if pulled low. The options are 2,4,5,6,7,8.
@@ -45,4 +39,4 @@ uart_2ndstage=1
 # Uncomment to instruct recovery.bin to send metadata including OTP fields
 # Specify -j dirname on the command line to specify the directory where
 # metadata should be stored (JSON format)
-#recovery_metadata=1
+recovery_metadata=1

--- a/secure-boot-recovery5/.gitignore
+++ b/secure-boot-recovery5/.gitignore
@@ -2,3 +2,4 @@ pieeprom.bin
 pieeprom.sig
 bootcode5.bin
 *signed_boot*
+metadata/

--- a/secure-boot-recovery5/README.md
+++ b/secure-boot-recovery5/README.md
@@ -58,8 +58,44 @@ The HSM wrapper script should:
 * Set nRPIBOOT jumper (or hold power button before power on) and remove EEPROM WP protection
 ```bash
 cd secure-boot-recovery5
-../rpiboot -d .
+mkdir -p metadata
+../rpiboot -d . -j metadata
 ```
+
+### Example UART output
+```
+3.04 OTP boardrev b04170 bootrom a a
+3.06 Customer key hash 8251a63a2edee9d8f710d63e9da5d639064929ce15a2238986a189ac6fcd3cee
+3.13 VC-JTAG unlocked
+3.36 RP1_BOOT chip ID: 0x20001927
+3.41 bootconf.sig
+3.41 hash: f71ede8fad8bea2f853bcff41173ffedde48c5b76ed46bc38fa057ce46e5d58b
+3.47 rsa2048: 3f215305d5aff620219da94f6f1294787e3a407102a507da96c28e9195d3ccb2f144cac66919f9d86ba9f54a8d20ff57c80d6d269e6e49a16dc23553974489947fe05bf3b7df5cd2c5040a9eebadca754ff4be50600b06fd9f565639adc859d88052e15e0ff6eecf7fec0386d41f81e5d009b04520bb83f17663b62b1271b9d27ec2344c73a20d42dfd68facd741d48c0453e8149448537abfed1d4805872c16182a3e9f25c0b86e002e88949d62c148a561aa8137c257ce0d3e0ae5761aa64c225e9c9782b2bb613de7d90499567c56218bb18a239d4347967b68b3ebd06eaa48215f16316d2a697bb2e67cb3883068f6284e2ca71d25ce0099a1ceb37a85c9
+3.94 RSA verify
+3.10 rsa-verify pass (0x0)
+
+```
+
+### Metadata
+The optional metadata argument causes rpiboot to readback the OTP information and write it to a JSON file in the given directory.
+This can be useful for debug or for storing in a provisioning database.
+
+Example metadata:
+```json
+{
+        "USER_SERIAL_NUM" : "a7eb274c",
+        "MAC_ADDR" : "2c:cf:67:70:76:f3",
+        "CUSTOMER_KEY_HASH" : "8251a63a2edee9d8f710d63e9da5d639064929ce15a2238986a189ac6fcd3cee",
+        "BOOT_ROM" : "0000000a",
+        "BOARD_ATTR" : "00000000",
+        "USER_BOARDREV" : "b04170",
+        "JTAG_LOCKED" : "0",
+        "MAC_WIFI_ADDR" : "2c:cf:67:70:76:f4",
+        "MAC_BT_ADDR" : "2c:cf:67:70:76:f5",
+        "FACTORY_UUID" : "001000911006186073"
+}
+```
+
 * Power ON the DUT
 
 ## Locking secure-boot mode
@@ -75,17 +111,8 @@ onwards:
 * It is not possible to downgrade to an old version of the bootloader that doesn't
   support secure boot.
 
-**WARNING: Modifications to OTP are irreversible. Once `revoke_devkey` has been set, it is not possible to unlock secure-boot mode or use a different private key.**
 
-To enable this, edit the `config.txt` file in this directory and set
-`program_pubkey=1`
-
-* `program_pubkey` - If 1, write the hash of the customer's public key to OTP.
-
-## Revoking the development key - NOT SUPPORTED YET
-* `revoke_devkey` - If 1, revoke the ROM bootloader development key, which
-   requires secure-boot mode and prevents downgrades to bootloader versions that
-   don't support secure boot.
+To enable this, edit the `config.txt` file in this directory and set `program_pubkey=1`
 
 ## Disabling VideoCore JTAG
 

--- a/secure-boot-recovery5/config.txt
+++ b/secure-boot-recovery5/config.txt
@@ -14,9 +14,6 @@ uart_2ndstage=1
 # Uncomment program_pubkey=1 to enable this
 # WARNING: THIS OPTION MODIFIES THE BCM2712 CHIP AND IS IRREVERSIBLE.
 #
-# N.B The revoke_keydey option is not required and not currently implemented
-# because on 2712 the bootloader firmware must also be signed by the customer
-# key if secure-boot is enabled.
 #program_pubkey=1
 
 # Permanently disable VideoCore JTAG access.
@@ -31,4 +28,4 @@ uart_2ndstage=1
 # Uncomment to instruct recovery.bin to send metadata including OTP fields
 # Specify -j dirname on the command line to specify the directory where
 # metadata should be stored (JSON format)
-#recovery_metadata=1
+recovery_metadata=1


### PR DESCRIPTION

Automatically set revoke_devkey if program_pubkey=1 because revoke_devkey=1 should always be set if secure-boot is used in production.

Tidyup the documentation for SIGNED_BOOT.