### PR TITLE
docs: Add metadata docs to the top level Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -188,6 +188,33 @@ Be careful not to overwrite `bootcode.bin` or `bootcode4.bin` with the executabl
 * Add `uart_2ndstage=1` to the `config.txt` file in `msd/` or `recovery/` directories to enable UART debug output.
 * Add `recovery_metadata=1` to the `config.txt` file in `recovery/` or `recovery5/` directory to enable metadata JSON output.
 
+## Reading device metadata from OTP via rpiboot
+The `rpiboot` "recovery" modules provide a facility to read the device OTP information. This can be run either as a provisioning step or as a standalone operation.
+
+To enable this make sure that `recovery_metadata=1` is set in the recovery `config.txt` file and pass the `-j metadata` flag to `rpiboot`.
+
+See [board revision](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#new-style-revision-codes-in-use) documentation to decode the `BOARD_ATTR` field.
+
+Example command to extract the OTP metadata from a Compute Module 4:
+```bash
+cd recovery
+mkdir -p metadata
+sudo rpiboot -j metadata -d .
+```
+
+Example metadata file contents written to `metadata/SERIAL_NUMBER.json`
+```json
+{
+        "MAC_ADDR" : "d8:3a:dd:05:ee:78",
+        "CUSTOMER_KEY_HASH" : "8251a63a2edee9d8f710d63e9da5d639064929ce15a2238986a189ac6fcd3cee",
+        "BOOT_ROM" : "0000c8b0",
+        "BOARD_ATTR" : "00000000",
+        "USER_BOARDREV" : "c03141",
+        "JTAG_LOCKED" : "0",
+        "ADVANCED_BOOT" : "0000e8e8"
+}
+```
+
 <a name="secure-boot"></a>
 ## Secure Boot
 This repository contains the low-level tools and firmware images for enabling secure-boot/verified boot on Compute Module 4 and  Compute Module 5.

--- a/recovery/config.txt
+++ b/recovery/config.txt
@@ -7,4 +7,4 @@
 # Uncomment to instruct recovery.bin to send metadata including OTP fields
 # Specify -j dirname on the command line to specify the directory where
 # metadata should be stored (JSON format)
-#recovery_metadata=1
+recovery_metadata=1

--- a/recovery5/config.txt
+++ b/recovery5/config.txt
@@ -7,4 +7,4 @@ uart_2ndstage=1
 # Uncomment to instruct recovery.bin to send metadata including OTP fields
 # Specify -j dirname on the command line to specify the directory where
 # metadata should be stored (JSON format)
-#recovery_metadata=1
+recovery_metadata=1


### PR DESCRIPTION
Also, enable metadata by default in the recovery config.txt files now that this feature has been supported for several APT releases.

Previously, this was not enabled by default because it might cause an old verison of the rpiboot host to output a file-not-found error.