### PR TITLE
rpi-make-boot-image: Fix FAT12 image generation

### DIFF
--- a/tools/rpi-make-boot-image
+++ b/tools/rpi-make-boot-image
@@ -205,16 +205,22 @@ createstaging() {
 
       IMAGE_SIZE="$((clusters * cluster_size))"
 
+      root_dir_sectors="$((((ROOT_DIR_ENTRIES * 32) + cluster_size - 1)/cluster_size))"
       # FAT32/FAT16 determined by number of clusters
       if [ "$clusters" -gt "65526" ]; then
          FAT_SIZE="32"
-	 fat_table_sectors="$(((((clusters + 2)*4) + SECTOR_SIZE - 1)/SECTOR_SIZE))"
-      else
+         fat_table_sectors="$(((((clusters + 2)*4) + SECTOR_SIZE - 1)/SECTOR_SIZE))"
+      elif [ "$clusters" -gt "4085" ]; then
          FAT_SIZE="16"
-	 fat_table_sectors="$(((((clusters + 2)*2) + SECTOR_SIZE - 1)/SECTOR_SIZE))"
-	 # Add some sectors based on ROOT_DIR_ENTRIES
-	 root_dir_sectors="$((((ROOT_DIR_ENTRIES * 32) + cluster_size - 1)/cluster_size))"
-	 fat_table_sectors="$((fat_table_sectors + root_dir_sectors))"
+         fat_table_sectors="$(((((clusters + 2)*2) + SECTOR_SIZE - 1)/SECTOR_SIZE))"
+         # Add some sectors based on ROOT_DIR_ENTRIES
+         fat_table_sectors="$((fat_table_sectors + root_dir_sectors))"
+      else
+         FAT_SIZE="12"
+         #12 bits per cluster = 3 bytes for 2 clusters
+         fat_table_sectors=$(((((clusters + 2)*3+1) / 2 + SECTOR_SIZE - 1)/SECTOR_SIZE))
+         # Add some sectors based on ROOT_DIR_ENTRIES
+         fat_table_sectors="$((fat_table_sectors + root_dir_sectors))"
       fi
       IMAGE_SIZE="$((IMAGE_SIZE + fat_table_sectors * SECTOR_SIZE))"
       IMAGE_SIZE="$(((IMAGE_SIZE + 1023)/1024))"


### PR DESCRIPTION
```

    rpi-make-boot-image: Fix FAT12 image generation

    mkfs.vfat -F option was not specified which caused mkfs to deduce the FAT type
    on it's own. For a small enough image FAT12 would be selected.

    805a4fda37cf580d4d9734a9ab6ddbf1d1b18ea9 introduced cluster calculation
    function that ends up only using FAT32 or FAT16. Creating a small image
    would fail with message : mkfs.fat: Not enough or too many clusters
    for filesystem - try less or more sectors per cluster
 ```