### PR TITLE
tools: verify HSM signature based on provided public key

### DIFF
--- a/tools/update-pieeprom.sh
+++ b/tools/update-pieeprom.sh
@@ -94,6 +94,9 @@ update_eeprom() {
            rpi-eeprom-digest \
               -i "${config}" -o "${TMP_CONFIG_SIG}" \
               -H "${HSM_WRAPPER}" || die "Failed to sign EEPROM config using HSM"
+           rpi-eeprom-digest \
+              -i "${config}" -v "${TMP_CONFIG_SIG}" \
+              -k "$public_pem_file" || die "Failed to verify EEPROM config signed by HSM"
         else
            rpi-eeprom-digest \
               -i "${config}" -o "${TMP_CONFIG_SIG}" \


### PR DESCRIPTION
If using an HSM, the public key is not derived, rather taken as an input parameter. In that case, however, it can happen that the user specifies a mismatching pubkey. This PR adds a check to make sure the pubkey belongs to the signature before embedding it further.

Fixes https://github.com/raspberrypi/usbboot/issues/319.