### PR TITLE
Make any keypress work to close the window

### DIFF
--- a/win32/rpi-mass-storage-gadget64.bat
+++ b/win32/rpi-mass-storage-gadget64.bat
@@ -6,4 +6,5 @@ rpiboot -d mass-storage-gadget64
 @echo EMMC/NVMe devices should be visible in the Raspberry Pi Imager in a few seconds.
 @echo For debug, you can login to the device using the USB serial gadget - see COM ports in Device Manager.
 @echo: 
-set /p dummy=Press a key to close this window.
+@echo | set /p dummy=Press a key to close this window.
+@pause > nul


### PR DESCRIPTION
The current version requires a "Enter" to cleanly close. This change makes "any" key work by using batch's `pause` command and some simple tricks to keep the output otherwise identical.