### PR TITLE
secure-boot-recovery5: Update docs to improve developer experience

### DIFF
--- a/secure-boot-recovery5/README.md
+++ b/secure-boot-recovery5/README.md
@@ -125,6 +125,11 @@ onwards:
 
 
 To enable this, edit the `config.txt` file in this directory and set `program_pubkey=1`
+before flashing the Pi firmware as described in the section `Programming the EEPROM image using rpiboot`.
+
+Note that the file `config.txt` in this directory is unrelated to the `config.txt` commonly
+found in the boot parition of Raspberry Pi OS. The file `config.txt` in this directory
+is used to configure the `rpiboot` tool.
 
 ## Disabling VideoCore JTAG
 


### PR DESCRIPTION
Hi there,

Recently I tried setting up secure boot on a pi5 and I had a lot of trouble wading through the docs and testing it.

In particular there was some confusion about the possibility to test booting from a signed `pieeprom.bin` EEPROM bootloader image without burning the OTP bits in the BCM2712. Seems other devs have had this issue, I found this forum post helpful at the time: https://forums.raspberrypi.com/viewtopic.php?t=370062

Most of this stuff should be pretty uncontroversial, just adding clarification about how the tools in this folder work.

However I would appreciate some feedback on the 2nd commit "secure-boot-recovery5: Document that BCM2172 needs burnt OTP to boot signed pieeprom.bin". The two LED blinks seems like an undocumented feature of the Pi 5. Just want to confirm my understanding is correct about the BCM2712 currently not booting a signed EEPROM image without first burning the public key into OTP. 