### PR TITLE
eeprom-erase: Add symlink for bootcode5.bin

### DIFF
--- a/eeprom-erase/bootcode5.bin
+++ b/eeprom-erase/bootcode5.bin
@@ -1,0 +1,1 @@
+../firmware/2712/recovery.bin


### PR DESCRIPTION
Rpiboot on Pi 5(00) / CM5 looks for bootcode5.bin. Add a symlink from 2712/recovery.bin to bootcode5.bin so the erase procedure also works for these boards. This mirrors the existing setup in recovery5/.