### PR TITLE
mass-storage-gadget: Remove mass-storage-gadget64-cm3

### DIFF
--- a/mass-storage-gadget64-cm3
+++ b/mass-storage-gadget64-cm3
@@ -1,0 +1,1 @@
+mass-storage-gadget64


### PR DESCRIPTION
The updated version of bootcode.bin supports boot.img ramdisks PiZero2W, CM3, CM0. Drop the redundant 64-bit mass-storage implemenation where files are loaded from the bootfiles.bin tar file instead of boot.img.