### PR TITLE
2711: msd: Remove support for legacy VPU MSD driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
     DEFAULT_MSG_DIR ?= $(INSTALL_PREFIX)/share/rpiboot/mass-storage-gadget64/
 endif
 
-rpiboot: main.c bootfiles.c decode_duid.c fmemopen.c msd/bootcode.h msd/start.h msd/bootcode4.h
+rpiboot: main.c bootfiles.c decode_duid.c fmemopen.c msd/bootcode.h msd/start.h
 	$(CC) -Wall -Wextra -g $(CPPFLAGS) $(CFLAGS) -o $@ main.c bootfiles.c decode_duid.c `pkg-config --cflags --libs libusb-1.0` -DGIT_VER="\"$(GIT_VER)\"" -DPKG_VER="\"$(PKG_VER)\"" -DBUILD_DATE="\"$(BUILD_DATE)\"" -DDEFAULT_MSG_DIR=\"$(DEFAULT_MSG_DIR)\" $(LDFLAGS)
 
 ifeq ($(HAVE_XXD),y)
@@ -39,7 +39,6 @@ install: rpiboot
 	install -d $(DESTDIR)$(INSTALL_PREFIX)/share/rpiboot/msd
 	install -d $(DESTDIR)$(INSTALL_PREFIX)/share/rpiboot/mass-storage-gadget64
 	install -m 644 msd/bootcode.bin  $(DESTDIR)$(INSTALL_PREFIX)/share/rpiboot/msd
-	install -m 644 msd/bootcode4.bin $(DESTDIR)$(INSTALL_PREFIX)/share/rpiboot/msd
 	install -m 644 msd/start.elf  $(DESTDIR)$(INSTALL_PREFIX)/share/rpiboot/msd
 	install -m 644 mass-storage-gadget64/boot.img $(DESTDIR)$(INSTALL_PREFIX)/share/rpiboot/mass-storage-gadget64
 	install -m 644 mass-storage-gadget64/config.txt $(DESTDIR)$(INSTALL_PREFIX)/share/rpiboot/mass-storage-gadget64

--- a/main.c
+++ b/main.c
@@ -10,7 +10,6 @@
 #include "decode_duid.h"
 #include "msd/bootcode.h"
 #include "msd/start.h"
-#include "msd/bootcode4.h"
 // 2712 doesn't use start5.elf
 
 /*
@@ -748,20 +747,10 @@ FILE * check_file(const char * dir, const char *fname, int use_fmem)
 	// is being used to check if a file exists.
 	if(fp == NULL && use_fmem)
 	{
-		if (bcm2711)
-		{
-			if(strcmp(fname, "bootcode4.bin") == 0)
-				fp = fmemopen(msd_bootcode4_bin, msd_bootcode4_bin_len, "rb");
-			else if(strcmp(fname, "start4.elf") == 0)
-				fp = fmemopen(msd_start_elf, msd_start_elf_len, "rb");
-		}
-		else
-		{
-			if(strcmp(fname, "bootcode.bin") == 0)
-				fp = fmemopen(msd_bootcode_bin, msd_bootcode_bin_len, "rb");
-			else if(strcmp(fname, "start.elf") == 0)
-				fp = fmemopen(msd_start_elf, msd_start_elf_len, "rb");
-		}
+		if(strcmp(fname, "bootcode.bin") == 0)
+			fp = fmemopen(msd_bootcode_bin, msd_bootcode_bin_len, "rb");
+		else if(strcmp(fname, "start.elf") == 0)
+			fp = fmemopen(msd_start_elf, msd_start_elf_len, "rb");
 		if (fp)
 			printf("Loading embedded: %s\n", fname);
 	}

--- a/msd/bootcode4.bin
+++ b/msd/bootcode4.bin
@@ -1,1 +1,0 @@
-../firmware/2711/bootcode4.bin


### PR DESCRIPTION
The legacy VPU firmware is extremely slow and cannot support all of the different SDRAM variants. This was superseded by the mass-storage-gadget a long time ago. The mass-storage-gadget runs the offical Broadcom DDR init sequence and Linux provides much higher throughput for USB mass-storage.

See: https://github.com/raspberrypi/usbboot/issues/391